### PR TITLE
Oppgraderer nodejs18-debian11 til sha256:117e714f608555028a18c8162db6246557ec667159d18714a4dd7a9ee5948be2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs18-debian11@sha256:dd8857b47881d5db49ff47089de4866178b71b24558a8583c20250754a387b7d
+FROM gcr.io/distroless/nodejs18-debian11@sha256:117e714f608555028a18c8162db6246557ec667159d18714a4dd7a9ee5948be2
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli