### PR TITLE
Oppgraderer Distroless til nodejs18-debian12@sha256:e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs18-debian11@sha256:117e714f608555028a18c8162db6246557ec667159d18714a4dd7a9ee5948be2
+FROM gcr.io/distroless/nodejs18-debian12@sha256:ee36c135f8391f1facc373d9e9c0445fde06b0ab45c514ef33b84163fe7ec14b
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli