### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:7715474a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:3f46c2fa879281ea5969d0aedd52ba1d82ed7687d0b68df850d2056564285efd
+FROM gcr.io/distroless/nodejs20-debian12@sha256:7715474a901a28e3edcdf7730f14b33e30c26085989ce04b0de163fe8fab0f03
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli