### PR TITLE
Fiks oppstartsfeil i Docker etter oppgradering til next 15.5.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/distroless/nodejs24-debian13@sha256:482fabdb0f0353417ab878532bb3bf45
 
 ENV NODE_ENV=production
 
-COPY /next.config.ts ./
+COPY /next.config.js ./
 COPY /.next ./.next
 COPY /public ./public
 COPY /node_modules ./node_modules

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-import { NextConfig } from 'next'
-
 export default {
     serverRuntimeConfig: {
         // Will only be available on the server side
@@ -10,4 +8,4 @@ export default {
         mockBackend: process.env.MOCK_BACKEND,
         localBackend: process.env.LOCAL_BACKEND,
     },
-} satisfies NextConfig
+}


### PR DESCRIPTION
Fjerne runtime-avhengigheten til lasting av TypeScript-konfigurasjon.
